### PR TITLE
1.3 Compatibility

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,4 @@
 (defproject joodie/clojure-refactoring "0.6.5-SNAPSHOT"
   :description "Clojure refactoring for Emacs/SLIME"
-  :dependencies [[org.clojure/clojure "1.2.0"]
-                 [org.clojure/clojure-contrib "1.2.0"]
+  :dependencies [[org.clojure/clojure "1.3.0"]
                  [net.cgrand/parsley "0.8.0"]])

--- a/src/clojure_refactoring/ast.clj
+++ b/src/clojure_refactoring/ast.clj
@@ -26,14 +26,13 @@
 ;; OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (ns clojure-refactoring.ast
-  (:use [clojure.contrib.seq-utils :only [find-first]]
-        [clojure.contrib.str-utils :only [str-join]])
   (:refer-clojure
    :exclude [symbol symbol? keyword? list vector newline conj])
-  (:require [clojure.core :as core])
-  (:use [clojure-refactoring.support.core
-         :exclude [sub-nodes tree-contains?]])
-  (:require [clojure-refactoring.support.parser :as parser])
+  (:use [clojure.contrib.seq-utils :only [find-first]]
+        [clojure.contrib.str-utils :only [str-join]]
+        [clojure-refactoring.support.core :exclude [sub-nodes tree-contains?]])
+  (:require [clojure.core :as core]
+            [clojure-refactoring.support.parser :as parser])
   (:import net.cgrand.parsley.Node))
 
 (defn make-node [tag content]

--- a/src/clojure_refactoring/destructuring.clj
+++ b/src/clojure_refactoring/destructuring.clj
@@ -26,7 +26,7 @@
 ;; OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (ns clojure-refactoring.destructuring
-  (:use clojure.walk
+  (:use [clojure.walk]
         [clojure-refactoring.support core]
         [clojure.contrib.seq-utils :only [find-first]]
         [clojure.contrib.str-utils :only [str-join]]

--- a/src/clojure_refactoring/extract_method.clj
+++ b/src/clojure_refactoring/extract_method.clj
@@ -27,10 +27,9 @@
 ;; OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (ns clojure-refactoring.extract-method
-  (:use [clojure-refactoring.support core formatter
-         find-bindings-above-node]
+  (:use [clojure-refactoring.support core formatter find-bindings-above-node]
         [clojure-refactoring.ast :only [defparsed-fn]]
-        clojure.set
+        [clojure.set]
         [clojure.contrib.seq-utils :only [find-first]])
   (:require [clojure-refactoring.ast :as ast]))
 

--- a/src/clojure_refactoring/support/core.clj
+++ b/src/clojure_refactoring/support/core.clj
@@ -26,15 +26,13 @@
 ;; OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (ns clojure-refactoring.support.core
-  (:use [clojure.contrib pprint]
-        [clojure.contrib.seq-utils :only [find-first]]
-        [clojure.walk :only [postwalk-replace]]))
+  (:use [clojure.pprint]))
 
 (defn format-code
   "Outputs code roughly how a human would format it."
    [node]
   (with-out-str
-    (with-pprint-dispatch *code-dispatch*
+    (with-pprint-dispatch code-dispatch
       (pprint node))))
 
 ;; Below stolen from arc

--- a/src/clojure_refactoring/support/find_bindings_above_node.clj
+++ b/src/clojure_refactoring/support/find_bindings_above_node.clj
@@ -26,10 +26,10 @@
 ;; OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (ns clojure-refactoring.support.find-bindings-above-node
-  (:use [clojure-refactoring.support core]
-        clojure-refactoring.ast.zip)
-  (:require [clojure.zip :as zip])
-  (:require [clojure-refactoring.ast :as ast]))
+  (:use [clojure-refactoring.support.core]
+        [clojure-refactoring.ast.zip])
+  (:require [clojure-refactoring.ast :as ast]
+            [clojure.zip :as zip]))
 
 (defn extract-binding-syms [ast]
   (if (#{"defmacro" "fn" "defn"}

--- a/src/clojure_refactoring/support/parser.clj
+++ b/src/clojure_refactoring/support/parser.clj
@@ -28,7 +28,7 @@
 
 
 (ns clojure-refactoring.support.parser
-  (:use net.cgrand.parsley ))
+  (:use net.cgrand.parsley))
 
 (def sexp
   (parser {:space [#{:whitespace :comment :discard} :*]

--- a/src/clojure_refactoring/support/replace.clj
+++ b/src/clojure_refactoring/support/replace.clj
@@ -26,8 +26,7 @@
 ;; OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (ns clojure-refactoring.support.replace
-  (:use [clojure-refactoring.support
-         source core paths])
+  (:use [clojure-refactoring.support source core paths])
   (:require [clojure-refactoring.ast :as ast]))
 
 (defn map-to-alist [m]

--- a/src/clojure_refactoring/support/source.clj
+++ b/src/clojure_refactoring/support/source.clj
@@ -28,8 +28,8 @@
 (ns clojure-refactoring.support.source
   (:use [clojure.contrib.find-namespaces :only [find-namespaces-in-dir]]
         [clojure-refactoring.support core paths])
-  (:import java.io.File)
-  (require [clojure-refactoring.support.parser :as parser]))
+  (:require [clojure-refactoring.support.parser :as parser])
+  (:import java.io.File))
 
 (defn- find-and-load [namespace]
   (when-not (find-ns namespace)

--- a/src/clojure_refactoring/thread_expression.clj
+++ b/src/clojure_refactoring/thread_expression.clj
@@ -26,11 +26,11 @@
 ;; OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (ns clojure-refactoring.thread-expression
-  (:use [clojure-refactoring.support core]
-        [clojure.walk :only [postwalk]]
-        clojure-refactoring.support.formatter)
-  (:require [clojure-refactoring.support.parser :as parser])
-  (:require [clojure-refactoring.ast :as ast]))
+  (:use [clojure.walk :only [postwalk]]
+        [clojure-refactoring.support core]
+        [clojure-refactoring.support.formatter])
+  (:require [clojure-refactoring.support.parser :as parser]
+            [clojure-refactoring.ast :as ast]))
 
 (def expression-threaders '#{->> -> clojure.core/->> clojure.core/->})
 

--- a/test/clojurecheck/core.clj
+++ b/test/clojurecheck/core.clj
@@ -1,8 +1,11 @@
-(when (= (class clojure.test/report) clojure.lang.MultiFn)
-  (eval
-   '(do (require 'clojure.test)
-       (ns clojure.test)
-       (def old-report clojure.test/report))))
+;; (when (= (class clojure.test/report) clojure.lang.MultiFn)
+;;   (eval
+;;    '(do (require 'clojure.test)
+;;         (ns clojure.test)
+;;         (def old-report clojure.test/report))))
+
+(ns clojure-refactoring.test.clojurecheck.core
+  (:use [clojure.test]))
 
 ; Copyright 2010 © Meikel Brandmeyer.
 
@@ -144,9 +147,11 @@
   [choices]
   (one-of (map constantly choices)))
 
-(def ^{:doc "Number of maximum retries to generate a valid value."
-       :added "2.0"}
-     *retries*
+(def
+  ^:dynamic
+  ^{:doc "Number of maximum retries to generate a valid value."
+    :added "2.0"}
+     retries
      2000)
 
 (defn generate
@@ -157,13 +162,13 @@
   returning a vector containing the keyword :retry."
   {:added "2.1"}
   [generator size]
-  (loop [n *retries*]
+  (loop [n retries]
     (if-not (zero? n)
       (let [[result value] (generator size)]
         (if (= result :retry)
           (recur (dec n))
           value))
-      (throw (Exception. (str "Retries exhausted (" *retries* " attempts)"))))))
+      (throw (Exception. (str "Retries exhausted (" retries " attempts)"))))))
 
 (defmacro let-gen
   "Takes a vector of let-like bindings. let-gen returns itself
@@ -302,13 +307,15 @@
   (let [f (if (fn? f) f (constantly f))]
     (comp gen f)))
 
-(def ^{:doc "Number of trials a property is tested with generated input.
+(def
+  ^:dynamic
+  ^{:doc "Number of trials a property is tested with generated input.
   Default is 1000."
-       :added "2.0"}
-     *trials*
-     100)
+    :added "2.0"}
+  trials
+  100)
 
-(defn *size-scale*
+(defn size-scale
   "The scale function used to scale up the size guidance with increasing
   trials while testing a property with generated input."
   {:added "2.0"}
@@ -332,9 +339,9 @@
         report-fn #(swap! results conj %)]
     (loop [n 1]
       (reset! results [])
-      (if (< *trials* n)
+      (if (< trials n)
         (report {:type :pass})
-        (let [input (-> n *size-scale* gen)]
+        (let [input (-> n size-scale gen)]
           (try
             (binding [report report-fn]
               (prop input))


### PR DESCRIPTION
Hello joodie,

I took a bit of time last night to get clojure-refactoring working with Clojure 1.3. The clojurecheck tests are still not passing due to `(recur)` being used across trys: `(loop []... (try ...yadda yadda... (recur...)))`

I also did some general namespace cleanup where I saw extraneous `use` or `require`.

If you have any questions let me know. Again, the tests aren't passing so there is a bit more work to be done, but I tested it after switching from `clojure.contrib.pprint` to `clojure.pprint`, and everything looks to be in working order.

Cheers,
Devin Walters (devn)
